### PR TITLE
DB Seeding

### DIFF
--- a/killfeed/db/db.go
+++ b/killfeed/db/db.go
@@ -11,6 +11,7 @@ import (
 
 type DBPool interface {
 	Close()
+	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	Ping(ctx context.Context) error
 	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)

--- a/killfeed/db/killmail.go
+++ b/killfeed/db/killmail.go
@@ -12,6 +12,22 @@ import (
 	"github.com/rusher2004/nerdb/killfeed/zkill"
 )
 
+type attackerWithKillmailID struct {
+	killmailID int
+	esi.KillmailAttacker
+}
+
+type victimWithKillmailID struct {
+	killmailID int
+	esi.KillmailVictim
+}
+
+type victimItemWithParentID struct {
+	esi.KillmailVictimItem
+	parentType string
+	parentID   int
+}
+
 // toAnySlice converts a slice of any type to a slice of any type https://go.dev/doc/faq#convert_slice_of_interface
 func toAnySlice[T any](i []T) []any {
 	out := make([]any, len(i))
@@ -20,6 +36,187 @@ func toAnySlice[T any](i []T) []any {
 	}
 
 	return out
+}
+
+func copyAny(ctx context.Context, tx pgx.Tx, schema, table, date string, cols []string, rows [][]any) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	b, err := tx.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("error beginning transaction: %w", err)
+	}
+
+	if err := createTempTable(ctx, b, schema, table, date); err != nil {
+		return fmt.Errorf("error creating temp table: %w", err)
+	}
+
+	count, err := copyToTempTable(ctx, b, schema, table+"_"+date, cols,
+		pgx.CopyFromSlice(
+			len(rows),
+			func(i int) ([]any, error) {
+				return rows[i], nil
+			},
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("error copying %s: %w", table, err)
+	}
+
+	toTable := schema + "." + table
+	fromTable := schema + "_" + table + "_" + date
+	if err := insertFromTempTable(ctx, b, toTable, fromTable); err != nil {
+		return fmt.Errorf("error inserting %s: %w", table, err)
+	}
+
+	log.Printf("copied %d %s(s)\n", count, table)
+
+	return nil
+}
+
+func copyAttackers(ctx context.Context, tx pgx.Tx, date string, attackers []attackerWithKillmailID) error {
+	var anyAttackers [][]any
+	for _, a := range attackers {
+		anyAttackers = append(anyAttackers, []any{a.killmailID, a.CharacterID, a.CorporationID, a.AllianceID, a.FactionID, a.DamageDone, a.FinalBlow, a.SecurityStatus, a.ShipTypeID, a.WeaponTypeID})
+	}
+
+	cols := []string{"esi_killmail_id", "esi_character_id", "esi_corporation_id", "esi_alliance_id", "esi_faction_id", "damage_done", "final_blow", "security_status", "ship_type_id", "weapon_type_id"}
+
+	return copyAny(ctx, tx, "killmail", "attacker", date, cols, anyAttackers)
+}
+
+func copyKillmails(ctx context.Context, tx pgx.Tx, date string, kms []esi.Killmail) error {
+	var anyKms [][]any
+	for _, k := range kms {
+		anyKms = append(anyKms, []any{k.KillmailID, k.KillmailTime, k.MoonID, k.SolarSystemID, k.WarID})
+	}
+
+	cols := []string{"esi_killmail_id", "time", "moon_id", "solar_system_id", "war_id"}
+
+	return copyAny(ctx, tx, "killmail", "esi_killmail", date, cols, anyKms)
+}
+
+func copyParticipants(ctx context.Context, tx pgx.Tx, date string, kms []esi.Killmail) error {
+	var participants []esi.KillMailParticipant
+	for _, k := range kms {
+		participants = append(participants, k.UniqueParticipants()...)
+	}
+
+	var allianceIDs, charIDs, corpIDs []int
+	for _, p := range participants {
+		if p.AllianceID.Valid && p.AllianceID.Int32 != 0 && !slices.Contains(allianceIDs, int(p.AllianceID.Int32)) {
+			allianceIDs = append(allianceIDs, int(p.AllianceID.Int32))
+		}
+
+		if !slices.Contains(charIDs, int(p.CharacterID.Int32)) {
+			charIDs = append(charIDs, int(p.CharacterID.Int32))
+		}
+
+		if p.CorporationID.Valid && p.CorporationID.Int32 != 0 && !slices.Contains(corpIDs, int(p.CorporationID.Int32)) {
+			corpIDs = append(corpIDs, int(p.CorporationID.Int32))
+		}
+	}
+
+	var anyChars [][]any
+	for _, c := range charIDs {
+		anyChars = append(anyChars, []any{c})
+	}
+	if err := copyAny(ctx, tx, "player", "character", date, []string{"esi_character_id"}, anyChars); err != nil {
+		return fmt.Errorf("error copying characters: %w", err)
+	}
+
+	var anyCorps [][]any
+	for _, c := range corpIDs {
+		anyCorps = append(anyCorps, []any{c})
+	}
+	if err := copyAny(ctx, tx, "player", "corporation", date, []string{"esi_corporation_id"}, anyCorps); err != nil {
+		return fmt.Errorf("error copying corporations: %w", err)
+	}
+
+	var anyAlliances [][]any
+	for _, a := range allianceIDs {
+		anyAlliances = append(anyAlliances, []any{a})
+	}
+	if err := copyAny(ctx, tx, "player", "alliance", date, []string{"esi_alliance_id"}, anyAlliances); err != nil {
+		return fmt.Errorf("error copying alliances: %w", err)
+	}
+
+	return nil
+}
+
+func copyToTempTable(ctx context.Context, p pgx.Tx, schema, table string, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error) {
+	return p.CopyFrom(ctx, pgx.Identifier{schema + "_" + table}, columnNames, rowSrc)
+}
+
+func copyVictims(ctx context.Context, tx pgx.Tx, date string, victims []victimWithKillmailID) error {
+	// var allVictimItems []victimItemWithParentID
+	// for _, v := range victims {
+	// 	for _, i := range v.Items {
+	// 		allVictimItems = append(allVictimItems, victimItemWithParentID{i, "victim", int(v.CharacterID.Int32)})
+	// 	}
+	// }
+
+	var anyVictims [][]any
+	for _, v := range victims {
+		var x, y, z *float64
+		if v.Position != nil {
+			x = &v.Position.X
+			y = &v.Position.Y
+			z = &v.Position.Z
+		}
+		anyVictims = append(anyVictims, []any{v.killmailID, v.CharacterID, v.CorporationID, v.AllianceID, v.FactionID, v.ShipTypeID, v.DamageTaken, x, y, z})
+	}
+
+	cols := []string{"esi_killmail_id", "esi_character_id", "esi_corporation_id", "esi_alliance_id", "esi_faction_id", "ship_type_id", "damage_taken", "position_x", "position_y", "position_z"}
+
+	if err := copyAny(ctx, tx, "killmail", "victim", date, cols, anyVictims); err != nil {
+		return fmt.Errorf("error copying victim: %w", err)
+	}
+
+	// if err := copyVictimItems(ctx, tx, date, allVictimItems); err != nil {
+	// 	return fmt.Errorf("error copying victim items: %w", err)
+	// }
+
+	return nil
+}
+
+// func copyVictimItems(ctx context.Context, tx pgx.Tx, date string, items []victimItemWithParentID) error {
+// 	var anyItems [][]any
+// 	for _, i := range items {
+// 		anyItems = append(anyItems, []any{i.parentID, i.parentType, i.Flag, i.ItemTypeID, i.QuantityDestroyed, i.QuantityDropped, i.Singleton})
+// 	}
+
+// 	cols := []string{"parent_id", "parent_type", "flag", "item_type_id", "quantity_destroyed", "quantity_dropped", "singleton"}
+
+// 	if err := copyAny(ctx, tx, "killmail", "victim_item", date, cols, anyItems); err != nil {
+// 		return fmt.Errorf("error copying victim items: %w", err)
+// 	}
+
+// 	// need to figure out how to reconcile nested items later. We need the victim_item_id of its
+// 	// parent to insert a nested item, which is not available until the parent item is inserted.
+// 	// for _, i := range items {
+// 	// 	if i.Items != nil {
+// 	// 		if err := copyVictimItems(ctx, tx, date, parentID, "item", *i.Items); err != nil {
+// 	// 			return fmt.Errorf("error copying victim item details: %w", err)
+// 	// 		}
+// 	// 	}
+// 	// }
+
+// 	return nil
+// }
+
+func createTempTable(ctx context.Context, tx pgx.Tx, fromSchema, fromTable, date string) error {
+	tableName := fromSchema + "_" + fromTable + "_" + date
+	query := `
+	CREATE TEMP TABLE IF NOT EXISTS ` + tableName + `
+	(LIKE ` + fromSchema + "." + fromTable + ` INCLUDING DEFAULTS)
+	ON COMMIT DROP;
+	`
+
+	_, err := tx.Exec(ctx, query)
+
+	return err
 }
 
 func insertAttackers(ctx context.Context, p DBPool, killmailID int, attackers []esi.KillmailAttacker) error {
@@ -41,6 +238,17 @@ func insertAttackers(ctx context.Context, p DBPool, killmailID int, attackers []
 	return nil
 }
 
+func insertFromTempTable(ctx context.Context, tx pgx.Tx, to, from string) error {
+	query := `
+	INSERT INTO ` + to + `
+	SELECT * FROM ` + from + `
+	ON CONFLICT DO NOTHING;
+	`
+	_, err := tx.Exec(ctx, query)
+
+	return err
+}
+
 func insertVictim(ctx context.Context, p DBPool, killmailID int, v esi.KillmailVictim) error {
 	query := `
 	INSERT INTO killmail.victim(esi_killmail_id, esi_character_id, esi_corporation_id, esi_alliance_id, esi_faction_id, ship_type_id, damage_taken, position_x, position_y, position_z)
@@ -56,37 +264,37 @@ func insertVictim(ctx context.Context, p DBPool, killmailID int, v esi.KillmailV
 		return nil
 	}
 
-	if err := insertVictimItems(ctx, p, killmailID, "victim", v.Items); err != nil {
-		return fmt.Errorf("error inserting victim items: %w", err)
-	}
+	// if err := insertVictimItems(ctx, p, killmailID, "victim", v.Items); err != nil {
+	// 	return fmt.Errorf("error inserting victim items: %w", err)
+	// }
 
 	return nil
 }
 
-func insertVictimItems(ctx context.Context, p DBPool, parentID int, parentType string, items []esi.KillmailVictimItem) error {
-	query := `
-	INSERT INTO killmail.victim_item(parent_id, parent_type, flag, item_type_id, quantity_destroyed, quantity_dropped, singleton)
-	VALUES ($1, $2, $3, $4, $5, $6, $7)
-	RETURNING victim_item_id;
-	`
+// func insertVictimItems(ctx context.Context, p DBPool, parentID int, parentType string, items []esi.KillmailVictimItem) error {
+// 	query := `
+// 	INSERT INTO killmail.victim_item(parent_id, parent_type, flag, item_type_id, quantity_destroyed, quantity_dropped, singleton)
+// 	VALUES ($1, $2, $3, $4, $5, $6, $7)
+// 	RETURNING victim_item_id;
+// 	`
 
-	for _, i := range items {
-		row := p.QueryRow(ctx, query, parentID, parentType, i.Flag, i.ItemTypeID, i.QuantityDestroyed, i.QuantityDropped, i.Singleton)
+// 	for _, i := range items {
+// 		row := p.QueryRow(ctx, query, parentID, parentType, i.Flag, i.ItemTypeID, i.QuantityDestroyed, i.QuantityDropped, i.Singleton)
 
-		var victimItemID int
-		if err := row.Scan(&victimItemID); err != nil {
-			return fmt.Errorf("error inserting victim item: %w", err)
-		}
+// 		var victimItemID int
+// 		if err := row.Scan(&victimItemID); err != nil {
+// 			return fmt.Errorf("error inserting victim item: %w", err)
+// 		}
 
-		if i.Items != nil {
-			if err := insertVictimItems(ctx, p, victimItemID, "item", *i.Items); err != nil {
-				return fmt.Errorf("error inserting victim item details: %w", err)
-			}
-		}
-	}
+// 		if i.Items != nil {
+// 			if err := insertVictimItems(ctx, p, victimItemID, "item", *i.Items); err != nil {
+// 				return fmt.Errorf("error inserting victim item details: %w", err)
+// 			}
+// 		}
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
 func upsertEntities(ctx context.Context, p DBPool, entities []int, entityType string) error {
 	if len(entities) == 0 {
@@ -187,6 +395,42 @@ func upsertZkillInfo(ctx context.Context, p DBPool, killmailID int, z zkill.ZKKi
 
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("no rows affected")
+	}
+
+	return nil
+}
+
+func (c *Client) CopyESIKillmails(ctx context.Context, date string, kms []esi.Killmail) error {
+	var allAttackers []attackerWithKillmailID
+	var allVictims []victimWithKillmailID
+	for _, k := range kms {
+		for _, a := range k.Attackers {
+			allAttackers = append(allAttackers, attackerWithKillmailID{int(k.KillmailID), a})
+		}
+
+		allVictims = append(allVictims, victimWithKillmailID{int(k.KillmailID), k.Victim})
+	}
+
+	if err := pgx.BeginFunc(ctx, c.pool, func(tx pgx.Tx) error {
+		if err := copyParticipants(ctx, tx, date, kms); err != nil {
+			return fmt.Errorf("error copying participants: %w", err)
+		}
+
+		if err := copyKillmails(ctx, tx, date, kms); err != nil {
+			return fmt.Errorf("error copying killmails: %w", err)
+		}
+
+		if err := copyAttackers(ctx, tx, date, allAttackers); err != nil {
+			return fmt.Errorf("error copying attackers: %w", err)
+		}
+
+		if err := copyVictims(ctx, tx, date, allVictims); err != nil {
+			return fmt.Errorf("error copying victims: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("transaction error: %w", err)
 	}
 
 	return nil

--- a/killfeed/main.go
+++ b/killfeed/main.go
@@ -77,6 +77,9 @@ func main() {
 		if err := g.Wait(); err != nil {
 			log.Fatalf("error running engine: %v", err)
 		}
+
+		log.Println("engine finished")
+		os.Exit(0)
 	}
 
 	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)

--- a/postgres/migrations/000001_init.down.sql
+++ b/postgres/migrations/000001_init.down.sql
@@ -1,0 +1,7 @@
+DROP schema IF EXISTS killmail CASCADE;
+
+DROP schema IF EXISTS player CASCADE;
+
+DROP schema IF EXISTS universe CASCADE;
+
+DROP TYPE IF EXISTS killmail.victim_item_parent_type CASCADE;

--- a/postgres/migrations/000001_init.up.sql
+++ b/postgres/migrations/000001_init.up.sql
@@ -1,0 +1,151 @@
+/*
+ functions
+ */
+CREATE OR REPLACE FUNCTION updated_timestamp() RETURNS TRIGGER AS $$ BEGIN NEW.updated_at := CURRENT_TIMESTAMP;
+
+RETURN NEW;
+
+END;
+
+$$ LANGUAGE PLPGSQL;
+
+/*
+ player schema
+ */
+CREATE SCHEMA IF NOT EXISTS player;
+
+CREATE TABLE player.character (
+  esi_character_id integer NOT NULL PRIMARY KEY,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE TRIGGER player_character_updated_trigger BEFORE
+UPDATE ON player.character FOR EACH ROW EXECUTE FUNCTION updated_timestamp();
+
+CREATE TABLE player.corporation (
+  esi_corporation_id integer NOT NULL PRIMARY KEY,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE TRIGGER player_corporation_updated_trigger BEFORE
+UPDATE ON player.corporation FOR EACH ROW EXECUTE FUNCTION updated_timestamp();
+
+CREATE TABLE player.alliance (
+  esi_alliance_id integer NOT NULL PRIMARY KEY,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE TRIGGER player_alliance_updated_trigger BEFORE
+UPDATE ON player.alliance FOR EACH ROW EXECUTE FUNCTION updated_timestamp();
+
+/*
+ killmail schema
+ */
+CREATE SCHEMA IF NOT EXISTS killmail;
+
+/*
+ types
+ */
+CREATE TYPE killmail.victim_item_parent_type AS enum ('victim', 'item');
+
+CREATE TABLE killmail.esi_killmail (
+  esi_killmail_id integer NOT NULL CONSTRAINT esi_killmail_pk PRIMARY KEY,
+  time timestamp NOT NULL,
+  moon_id integer,
+  solar_system_id integer NOT NULL,
+  war_id integer,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE TRIGGER killmail_esi_killmail_updated_trigger BEFORE
+UPDATE ON killmail.esi_killmail FOR EACH ROW EXECUTE FUNCTION updated_timestamp();
+
+CREATE TABLE killmail.zkill_info (
+  zkill_info_id serial PRIMARY KEY,
+  esi_killmail_id integer NOT NULL CONSTRAINT zkill_info_pk UNIQUE REFERENCES killmail.esi_killmail(esi_killmail_id),
+  awox boolean NOT NULL,
+  destroyed_value numeric(17, 2) NOT NULL,
+  dropped_value numeric(17, 2) NOT NULL,
+  fitted_value numeric(17, 2) NOT NULL,
+  hash text NOT NULL,
+  location_id integer,
+  npc boolean NOT NULL,
+  points integer NOT NULL,
+  solo boolean NOT NULL,
+  total_value numeric(17, 2) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE TRIGGER killmail_zkill_info_updated_trigger BEFORE
+UPDATE ON killmail.zkill_info FOR EACH ROW EXECUTE FUNCTION updated_timestamp();
+
+CREATE TABLE killmail.victim (
+  esi_character_id integer REFERENCES player.character(esi_character_id),
+  esi_killmail_id integer NOT NULL REFERENCES killmail.esi_killmail(esi_killmail_id),
+  damage_taken integer NOT NULL,
+  esi_alliance_id integer,
+  esi_corporation_id integer,
+  esi_faction_id integer,
+  position_x double precision,
+  position_y double precision,
+  position_z double precision,
+  ship_type_id integer NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE TRIGGER killmail_victim_updated_trigger BEFORE
+UPDATE ON killmail.victim FOR EACH ROW EXECUTE FUNCTION updated_timestamp();
+
+CREATE TABLE killmail.attacker (
+  esi_character_id integer REFERENCES player.character(esi_character_id),
+  esi_killmail_id integer NOT NULL REFERENCES killmail.esi_killmail(esi_killmail_id),
+  damage_done integer NOT NULL,
+  esi_alliance_id integer,
+  esi_corporation_id integer,
+  esi_faction_id integer,
+  final_blow boolean NOT NULL,
+  security_status double precision,
+  ship_type_id integer,
+  weapon_type_id integer,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE TRIGGER killmail_attacker_updated_trigger BEFORE
+UPDATE ON killmail.attacker FOR EACH ROW EXECUTE FUNCTION updated_timestamp();
+
+CREATE TABLE killmail.victim_item (
+  victim_item_id serial PRIMARY KEY,
+  parent_id integer NOT NULL,
+  parent_type killmail.victim_item_parent_type NOT NULL,
+  flag integer NOT NULL,
+  item_type_id integer NOT NULL,
+  quantity_destroyed integer,
+  quantity_dropped integer,
+  singleton integer NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE TRIGGER killmail_victim_item_updated_trigger BEFORE
+UPDATE ON killmail.victim_item FOR EACH ROW EXECUTE FUNCTION updated_timestamp();
+
+/*
+ universe schema
+ */
+CREATE SCHEMA IF NOT EXISTS universe;
+
+CREATE TABLE universe.faction (
+  esi_faction_id integer PRIMARY KEY,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE TRIGGER universe_faction_updated_trigger BEFORE
+UPDATE ON universe.faction FOR EACH ROW EXECUTE FUNCTION updated_timestamp();


### PR DESCRIPTION
The script to copy historical data provided by EveRef is essentially done. 

Some notes: 

I decided to leave storing victim items out. It roughly tripled the size of the database, and doesn't carry much value, since the zkill info has damage value totals.

I still need to create a mechanism to fetch zkill only data for killmails that are lacking it. zkill's site says to use a 'reasonable' rate limit when fetching batches of data directly, and I want to confirm what reasonable is before I start fetching tens of millions of killmails.

